### PR TITLE
Fix HygraphLoaderOptions variables type

### DIFF
--- a/src/HygraphLoader.ts
+++ b/src/HygraphLoader.ts
@@ -15,7 +15,7 @@ export interface HygraphLoaderOptions {
   /** The operation to fetch from the API */
   operation: string | IOperation;
   /** The GraphQL variables to pass to the API */
-  variables?: Array<object>;
+  variables?: Record<string, Extract<VariableOptions, { value: any }>>;
   /** The rich text field to render */
   richText?: string;
 }


### PR DESCRIPTION
Fixes 2 issues related to `HygraphLoaderOptions` **variables**

1. Spreading array creates invalid variable aliases in query. Fixes #6 
2. Narrows down the type of `VariableOptions`. Most of the Hygraph queries require precise types of variables to go through

